### PR TITLE
Fix `getSpringLenths()` return type

### DIFF
--- a/src/objects/cylindermesh.hpp
+++ b/src/objects/cylindermesh.hpp
@@ -66,7 +66,7 @@ public:
 		);
 	}
 
-	std::tuple<int, int, int> getSpringLengths()
+	std::tuple<float, float, float> getSpringLengths()
 	{
 		return springLengths;
 	}


### PR DESCRIPTION
Hotfix